### PR TITLE
Incorporated feedback from Shlok

### DIFF
--- a/mosaic/mosaic.tex
+++ b/mosaic/mosaic.tex
@@ -81,7 +81,7 @@ Decentralized applications can use Mosaic to compute over a composed network of 
 
 A decentralized application is an application for which the computation is requested, performed, and paid for by independent actors.
 To ensure correct execution of decentralized computations first an order on the inputs of execution must be determinable.
-To date Ethereum is the leading network
+To date, Ethereum is the leading network
 % {TODO: quantify and reference; also define Ethereum as an instruction set, a mainnet network}
 of nodes that enables developers to write and deploy code which can be called by independent users to collectively construct a shared state of the application.
 
@@ -94,7 +94,7 @@ However, PoW produces a serial execution model and nodes cannot be collectively 
 
 % NOTE: Ethereumv2 still needs to serialise all execution; DFinity starts from scratch 
 Active research and implementation work is ongoing to scale Ethereum's transaction throughput by dividing the verification work into multiple sections, also referred to as \emph{shards}.
-At the same time Ethereum is committed to moving from the probabilistic Proof-of-Work consensus engine to a BFT based Proof-of-Stake (PoS) consensus engine.\footnote{
+At the same time, Ethereum is committed to moving from the probabilistic Proof-of-Work consensus engine to a BFT based Proof-of-Stake (PoS) consensus engine.\footnote{
 	\url{https://github.com/ethereum/eth2.0-specs/blob/master/specs/casper_sharding_v2.1.md}
 }
 The outset of a BFT consensus engine is to collectively produce a blockchain which provably -- under certain honesty assumptions -- cannot finalise conflicting blocks.
@@ -107,7 +107,7 @@ Thus far a vision for a decentralized web has been a major driver of innovation.
 However, to power global networks of billions of users and decentralized computation on vast decentralized data stores, it is reasonable to assume no single blockchain network will suffice as a backbone for all types of applications.
 Much like the internet is a composed network of networks, we can conceive decentralized applications to transcend any single blockchain and execute across a network of blockchain networks.
 
-In this work we detail two protocols.
+We detail two protocols in this work.
 The first, a layer-2 protocol, constructs \emph{meta-blockchains} on top of existing blockchain networks to extend their state space and transaction throughput capacity.
 The second protocol, called a \emph{gateway}, acts as a message bus to send typed messages atomically between the underlying layer-1 blockchain and the meta-blockchain running on top of it.
 
@@ -133,14 +133,14 @@ and similarly consider an auxiliary system $A$ with state transition rules $t_A$
 
 
 Transition rules for the origin and auxiliary system can be similar but do not have to be.
-In our discussion, when we need an example, we will reference to the origin blockchain as Ethereum (Byzantium), running Proof-of-Work, and for the auxiliary system we consider Go-Ethereum, running ``clique'' Proof-of-Authority (PoA).
+In our discussion, when we need an example, we will refer to the origin blockchain as Ethereum (Byzantium), running Proof-of-Work, and for the auxiliary system we consider Go-Ethereum, running ``clique'' Proof-of-Authority (PoA).
 We deliberately use PoA for our considerations for the auxiliary system to emphasise that the security for the composed auxiliary system is not derived from the consensus engine of the auxiliary system.
 Rather the security properties of the composed system must rely only on the security properties of the consensus rules of the origin blockchain and on the Mosaic BFT consensus rules composing the auxiliary system into the origin system.\footnote{
 	The block proposers of the auxiliary system do have the ability to censor transactions from the auxiliary system if they have an ability to collude.
 }
 
 
-On the origin blockchain we define a meta-blockchain $\mathcal{B}$ with a staked validator set $\mathcal{V}_\mathcal{B}$. The blocks $B_i$ of $\mathcal{B}$ are committed to a \emph{core} contract on origin $O$.
+We define a meta-blockchain $\mathcal{B}$ with a staked validator set $\mathcal{V}_\mathcal{B}$ on the origin blockchain. The blocks $B_i$ of $\mathcal{B}$ are committed to a \emph{core} contract on origin $O$.
 For a given history of $O$,\footnote{
 	The origin blockchain $O$ might be probabilistically finalised, in which case a transaction to a contract can always assert that it is valid only on the intended branch of history by referencing a historical blockhash.
 }
@@ -169,7 +169,7 @@ A $\texttt{+}\sfrac{2}{3}$ supermajority signing of the same link makes it a sup
 	The genesis block of the auxiliary blockchain is considered justified by definition.
 }
 
-In the work it is shown that checkpoints along a justified chain can additionally be considered \emph{finalised}, if and only if they are justified themselves and their direct child checkpoint is justified.
+In the work, it is shown that checkpoints along a justified chain can additionally be considered \emph{finalised}, if and only if they are justified themselves and their direct child checkpoint is justified.
 It is then shown that, should validators finalise a checkpoint on a contradicting branch of the history of the underlying blockchain, minimally $\sfrac{1}{3}$ of the validator weight must have signed vote messages that violate either one of two rules: \emph{the Casper slashing conditions}.
 
 These slashing conditions can be intrinsically validated given two signed vote messages from a validator $v$.
@@ -199,7 +199,7 @@ A validator $v \in \mathcal{V}_\mathcal{B}$ must never sign two externalised vot
 \end{enumerate}
 
 As the slashing conditions can be intrinsically asserted to have been violated given two externalised vote messages by the same validator, there is no communication overhead to assert a possible violation of these conditions on the origin blockchain; even if the justified chain is being constructed on the auxiliary system.
-As a result the validators in $\mathcal{V}_\mathcal{B}$ can be held accountable on the origin blockchain for their voting actions on the auxiliary system.
+As a result, the validators in $\mathcal{V}_\mathcal{B}$ can be held accountable on the origin blockchain for their voting actions on the auxiliary system.
 The slashing condition can be asserted on both systems and there is a clear incentive for the honest validators to assert any violation without delay on both the origin and auxiliary system, naturally synchronising the validator weights when such an event occurs.
 
 We will later in this work address a dynamic validator set $\mathcal{V}_\mathcal{B}$, where validators can join and log out on the origin system.
@@ -212,7 +212,7 @@ However, already with a static validator set, we can observe that the finality g
 \subsection{Observing origin}
 \label{observing_origin}
 
-Per construction the finalisation of the auxiliary system by the Mosaic validators economically binds the block proposers of the auxiliary system to the Mosaic fork selection.
+Per construction, the finalisation of the auxiliary system by the Mosaic validators economically binds the block proposers of the auxiliary system to the Mosaic fork selection.
 By finalising the auxiliary system the Mosaic validators reach consensus about the auxiliary system itself.
 However, to construct a meta-blockchain we will additionally require the Mosaic validators to reach consensus about their observation of the origin blockchain on the auxiliary system.
 This is required so that message can pass bidirectionally between the chains.
@@ -240,7 +240,7 @@ Assume an observed checkpoint $a$ was finalised on a contradictory branch of ori
 Any honest node can challenge the finalisation of $b$ on origin by presenting the finalisation of $a$ and demonstrating that $a \notin \text{history}(b)$.
 Note that if validators would want to alter the finalised observation from $o \rightarrow a \rightarrow b$ to $o \rightarrow b$ they would have to produce vote messages violating the slashing conditions given the already existing vote messages.
 
-Upon success the challenger is rewarded from the stake of the offending validators and the core contract must declare the meta-blockchain halted.
+Upon success, the challenger is rewarded from the stake of the offending validators and the core contract must declare the meta-blockchain halted.
 
 \subsection{Calculating the transition objects}
 
@@ -327,7 +327,7 @@ Our concern now is to assert that the state transition to $s$ from the last comm
 The core contract on origin must declare the meta-blockchain halted when it can slash more than the safety threshold of $\mathcal{V}_{\mathcal{B}_i}$ at a single meta-blockchain height $i$.\footnote{When a meta-blockchain has been halted, assets and stateful objects can be recovered on the origin blockchain at any later time with Merkle proofs against the last committed state root of the meta-blockchain.
 We will detail the conditions under which a meta-blockchain must halt and how the recovery processes can work later in this writing.}
 
-Alternatively no contradictory finalisation $s'$ of the auxiliary system relative to $s$ exists.
+Alternatively, no contradictory finalisation $s'$ of the auxiliary system relative to $s$ exists.
 Under the security model assuming a $\texttt{+}\sfrac{2}{3}$ supermajority of the validator weight is honest, it follows that the proposed state transition to $s$ has been obtained through honest verification of all transactions under the state transition rules $t_A$.
 
 Before continuing we summarise that the proposal mechanism to commit a meta-block is asynchronous, requires no leadership-selection and is proven to be Byzantine fault-tolerant under the security model of an honest supermajority.
@@ -433,9 +433,9 @@ When a validator casts a vote on auxiliary, the vote carries a specific weight.
 The initial weight of a new validator is equal to the stake on origin.
 When we say that a vote receives a $\sfrac{2}{3}$ majority, we mean that at least $\sfrac{2}{3}$ of the total voting weight on auxiliary have cast that vote.
 A validator's stake may be reduced to a non-zero value, e.g. by slashing.
-However, in any slashing case the weight will always go to zero immediately.
+However, the weight will always go to zero immediately in any slashing case.
 
-We defend against long range revision attacks the same way casper does.
+We defend against long-range revision attacks the same way Casper does.
 Four months after the validator left the set of validators, the validator can withdraw its stake.
 
 Casper FFG\cite{casperffg} defines a stitching mechanism for a changing set of validators.
@@ -563,7 +563,7 @@ If block proposers would fail to produce a sufficient deposit for validator rewa
 \section{A mosaic of cores}
 
 summary:
-by constructing asynchronous BFT consensus rules to compose a heterogeneous auxiliary blockchain into the origin blockchain, we leverage the security of the origin blockchain to asynchronously finalise the transactions on the auxiliary blockchain.
+By constructing asynchronous BFT consensus rules to compose a heterogeneous auxiliary blockchain into the origin blockchain, we leverage the security of the origin blockchain to asynchronously finalise the transactions on the auxiliary blockchain.
 As there are no time constraints or time-outs in the Mosaic consensus rules, the limited processing capacity of the origin blockchain does not undercut the ability to compose many auxiliary systems into the same origin blockchain.
 This enables Mosaic to run many meta-blockchains in parallel, additively improving the total transaction capacity, but keeping a bound on the cost imposed on the origin blockchain.
 %% 


### PR DESCRIPTION
An open question @benjaminbollen:
We sometime write things like "even if they sufficiently trailed the head of origin". It should probably be either one of the following two changes instead:
1. even if they sufficiently trailed the head of the origin
2. even if they sufficiently trailed the head of Origin

Origin should either be a thing (adding the definite article "the" before it) or it should be a name (and thus capitalised).
What's your preference?