### PR TITLE
Replaced conflicting blocks with forks

### DIFF
--- a/mosaic/mosaic.tex
+++ b/mosaic/mosaic.tex
@@ -97,7 +97,7 @@ Active research and implementation work is ongoing to scale Ethereum's transacti
 At the same time, Ethereum is committed to moving from the probabilistic Proof-of-Work consensus engine to a BFT based Proof-of-Stake (PoS) consensus engine.\footnote{
 	\url{https://github.com/ethereum/eth2.0-specs/blob/master/specs/casper_sharding_v2.1.md}
 }
-The outset of a BFT consensus engine is to collectively produce a blockchain which provably -- under certain honesty assumptions -- cannot finalize conflicting blocks.
+The outset of a BFT consensus engine is to collectively produce a blockchain which provably -- under certain honesty assumptions -- cannot finalize conflicting forks.
 
 % A second body of work constructs Proof-of-Stake blockchain systems by emulating Proof-of-Work's block proposal mechanism through pseudorandomly assigning to stakeholders the right to append new blocks\footnote{Peercoin, }.
 


### PR DESCRIPTION
In this place, it could make more sense to say forks instead of blocks
as forking is prevented.